### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ AngularJS module for [ademilter's bricklayer](https://github.com/ademilter/brick
     ```html
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bricklayer/0.4.3/bricklayer.min.css">
     <script src="//cdnjs.cloudflare.com/ajax/libs/bricklayer/0.4.3/bricklayer.min.js"></script>
-    <script src="//cdn.jsdelivr.net/angular.bricklayer/1.1.0/angular-bricklayer.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/angular-bricklayer@1.1.0/dist/angular-bricklayer.min.js"></script>
     ```
     4. When using downloaded files
     ```html


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/angular-bricklayer.

Feel free to ping me if you have any questions regarding this change.